### PR TITLE
Basic nix flake with package build

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,6 @@
+{ rustPlatform }:
+rustPlatform.buildRustPackage {
+  name = "dyd";
+  src = ./.;
+  cargoHash = "sha256-VduByUoO4aeGQfSpNcVxmJlYrpmGF6XLdC040YsDuO4=";
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,25 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1697793076,
+        "narHash": "sha256-02e7sCuqLtkyRgrZmdOyvAcQTQdcXj+vpyp9bca6cY4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "038b2922be3fc096e1d456f93f7d0f4090628729",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,16 @@
+{
+  outputs = { self, nixpkgs }:
+    let
+      forAllSystems = generate:
+        nixpkgs.lib.genAttrs [
+          "aarch64-darwin"
+          "x86_64-linux"
+        ]
+          (system: generate nixpkgs.legacyPackages.${system});
+    in
+    {
+      packages = forAllSystems (pkgs: {
+        default = pkgs.callPackage ./default.nix { };
+      });
+    };
+}


### PR DESCRIPTION
@sax mentioned that you'd like help packaging dyd with nix. Here's an example - I won't be upset if you don't want to add nix stuff to this repo though.

The results of this allows you to:

```
nix run github:code-supply/dyd/nix
```

Which would change to the following if merged:

```
nix run github:synchronal/dyd
```

The `default.nix` is extremely minimal and would probably want fleshing out with other fields from [buildRustPackage](https://nixos.org/manual/nixpkgs/stable/#compiling-rust-applications-with-cargo) before being PR'd into nixpkgs, if that was something you wanted to do.

There are other ways of packaging Rust apps, such as [dream2nix](https://github.com/nix-community/dream2nix) and [buildRustCrate](https://nixos.org/manual/nixpkgs/stable/#compiling-rust-crates-using-nix-instead-of-cargo). I don't have much experience packaging rust apps in general, though.

Happy to go through this at some point!