### PR TITLE
Compatibility with latest nixpkgs on Darwin

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,8 @@
-{ lib, rustPlatform }:
+{ lib
+, stdenv
+, rustPlatform
+, darwin
+}:
 
 let
   cargoToml = builtins.readFile ./Cargo.toml;
@@ -15,6 +19,8 @@ rustPlatform.buildRustPackage {
   cargoLock = {
     lockFile = ./Cargo.lock;
   };
+
+  buildInputs = lib.lists.optional stdenv.isDarwin darwin.apple_sdk.frameworks.SystemConfiguration;
 
   meta = with lib; {
     description = "Daily diff";


### PR DESCRIPTION
Include SystemConfiguration framework at runtime.

This can be proven by setting the nixpkgs input in the flake to e.g. "master", but there's no need to include that by default.